### PR TITLE
Get /js/socket.io.js from esup-otp-api : avoid use of cdn.

### DIFF
--- a/src/main/resources/templates/esupOtpCodeView.html
+++ b/src/main/resources/templates/esupOtpCodeView.html
@@ -158,7 +158,7 @@
                 }
 
             </script>
-            <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.0.3/socket.io.js"></script>
+            <script th:src="${apiUrl} + '/js/socket.io.js'"></script>
     </div>
 </div>
 </main>


### PR DESCRIPTION
Conditionné par https://github.com/EsupPortail/esup-otp-api/pull/8